### PR TITLE
Use latest Dockware image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   shopware:
-    image: dockware/dev:6.4.20.1
+    image: dockware/dev:latest
     container_name: shopware
     ports:
       - "8080:80"


### PR DESCRIPTION
This PR updates the Dockware version used on the Docker image to instantiate Shopware 6.6.x.x instance to test out the latest version of the plugin (V4.x.x).